### PR TITLE
Either improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -123,8 +123,10 @@ in lib.fix (self: {
       };
   };
 
-  either = t1: t2: typedef "either<${t1.name},${t2.name}>"
-    (x: (self.type t1).check x || (self.type t2).check x);
+  eitherN = tn: typedef "either<${concatStringsSep ", " (map (x: x.name) tn)}>"
+    (x: any (t: (self.type t).check x) tn);
+
+  either = t1: t2: self.eitherN [ t1 t2 ];
 
   list = t: typedef' rec {
     name = "list<${t.name}>";

--- a/tests.nix
+++ b/tests.nix
@@ -80,6 +80,7 @@ deepSeq rec {
     any bool drv float int string path
 
     (attrs int)
+    (eitherN [ int string bool ])
     (either int string)
     (enum [ "foo" "bar" ])
     (list string)


### PR DESCRIPTION
Fixes #4 
I have also added a match for either which tries to match as the sum type. As the types in an either may not be disjoint (as they are in a sum) I have made the types coming "earlier" in the either take priority. If this is not desired then I can remove it but I feel it has use cases.