### PR TITLE
Open structs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -93,6 +93,7 @@ with builtins; let
 in lib.fix (self: {
   # Primitive types
   any      = typedef "any" (_: true);
+  none     = typedef "none" (_: false);
   int      = typedef "int" isInt;
   bool     = typedef "bool" isBool;
   float    = typedef "float" isFloat;

--- a/default.nix
+++ b/default.nix
@@ -129,6 +129,11 @@ in lib.fix (self: {
 
   either = t1: t2: self.eitherN [ t1 t2 ];
 
+  intersectN = tn: typedef "intersect<${concatStringsSep "," (map (x: x.name) tn)}>"
+    (x: (all (t: (self.type t).check x) tn));
+
+  intersect = t1: t2: self.intersectN [ t1 t2 ];
+
   list = t: typedef' rec {
     name = "list<${t.name}>";
 

--- a/tests.nix
+++ b/tests.nix
@@ -31,12 +31,15 @@ deepSeq rec {
       email = string;
       phone = option string;
     });
+
+    _ = bool;
   };
 
   testPerson = person {
     name = "Brynhjulf";
     age  = 42;
     contact.email = "brynhjulf@yants.nix";
+    otherInfo = true;
   };
 
   # Test enum definitions & matching

--- a/tests.nix
+++ b/tests.nix
@@ -77,7 +77,7 @@ deepSeq rec {
 
   # Test that all types are types.
   testTypes = map type [
-    any bool drv float int string path
+    any none bool drv float int string path
 
     (attrs int)
     (eitherN [ int string bool ])

--- a/tests.nix
+++ b/tests.nix
@@ -20,6 +20,7 @@ deepSeq rec {
     (option int null)
     (list string [ "foo" "bar" ])
     (either int float 42)
+    (intersect string any "foo")
   ];
 
   # Test that structures work as planned.
@@ -72,6 +73,22 @@ deepSeq rec {
     pet = v: throw "It's not supposed to be a pet!";
   };
 
+  # Intersection test
+  a = struct "A" {
+    x = bool;
+    _ = any;
+  };
+
+  b = struct "B" {
+    y = int;
+    _ = any;
+  };
+
+  intersectTest = (intersect a b) {
+    x = true;
+    y = 42;
+  };
+
   # Test curried function definitions
   func = defun [ string int string ]
   (name: age: "${name} is ${toString age} years old");
@@ -85,6 +102,7 @@ deepSeq rec {
     (attrs int)
     (eitherN [ int string bool ])
     (either int string)
+    (intersect string any)
     (enum [ "foo" "bar" ])
     (list string)
     (option int)


### PR DESCRIPTION
Fixes #6 

Added a none type of which nothing satisfies.
Adds a special field `_` to structs which causes a struct to be open. For example
```
struct {
  x = bool;
  _ = int;
}
```
Must contain an `x` of type `bool` and then can contain any number (including 0) of other fields of type `int`. If you do not care what type the other fields are you can use `_ = any;`.
Closed structs are represented as having `_ = none;` and this is automatically put in to struct that do not contain a `_` field.

Have added intersection types.

Have added reasonable tests for each of these things